### PR TITLE
Add pip as a dependency in the environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - jupyterlab=3.4.0
   - pygmt=0.6.1
   - python=3.9
+  - pip=22
   # Optional dependencies
   - geopandas=0.10.2
   - jupyter-book=0.12.3


### PR DESCRIPTION
Got this message when creating the environment:

    Warning: you have pip-installed dependencies in your environment
    file, but you do not list pip itself as one of your conda dependencies.
    Conda may not use the correct pip to install your packages, and they may
    end up in the wrong place. Please add an explicit pip dependency.  I'm
    adding one for you, but still nagging you.