### PR TITLE
 Install dependencies with mamba instead of pip

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -4,7 +4,7 @@ name: deploy-book
 # Only run this when the main branch changes
 on:
   # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
-  # pull_request:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -4,7 +4,7 @@ name: deploy-book
 # Only run this when the main branch changes
 on:
   # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
-  pull_request:
+  # pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
     # Checkout current git repository
     - name: Checkout
@@ -28,7 +32,7 @@ jobs:
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2.1.1
       with:
-        activate-environment: pygmt
+        activate-environment: egu22pygmt
         environment-file: environment.yml
         python-version: ${{ matrix.python-version }}
         channels: conda-forge

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -20,16 +20,27 @@ jobs:
   deploy-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.0.2
+    # Checkout current git repository
+    - name: Checkout
+      uses: actions/checkout@v3.0.2
 
-    # Install dependencies
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3.1.2
+    # Install Mambaforge with conda-forge dependencies
+    - name: Setup Mambaforge
+      uses: conda-incubator/setup-miniconda@v2.1.1
       with:
-        python-version: 3.9
+        activate-environment: pygmt
+        environment-file: environment.yml
+        python-version: ${{ matrix.python-version }}
+        channels: conda-forge
+        channel-priority: strict
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
+        mamba-version: "*"
+        use-mamba: true
 
-    - name: Install dependencies
-      run: pip install -r book/requirements.txt
+    # Show installed pkg information for postmortem diagnostic
+    - name: List installed packages
+      run: mamba list
 
     # Build the book
     - name: Build the book

--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -1,3 +1,0 @@
-jupyter-book
-matplotlib
-numpy


### PR DESCRIPTION
Change the Continuous Integration to use mamba instead of pip, so that GMT and PyGMT can be installed from conda-forge.

Resolves https://github.com/GenericMappingTools/egu22pygmt/pull/3#discussion_r866279703.