### PR TITLE
Pin lazrs to 0.4.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
   - laspy=2.1.2
   - rioxarray=0.11.1
   - pip:
-    - lazrs==0.4.1
+    - lazrs==0.4.0


### PR DESCRIPTION
Trying to fix issue on Binder `ERROR: Could not find a version that satisfies the requirement lazrs==0.4.1 (from versions: 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5, 0.3.0, 0.3.1, 0.4.0a1, 0.4.0)
ERROR: No matching distribution found for lazrs==0.4.1`. Quite strange since there is a lazrs==0.4.1 at https://pypi.org/project/lazrs/0.4.1/#files

Button to test this branch: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GenericMappingTools/egu22pygmt/lazrs-0.4.0)