### PR TITLE
Update download link of mola32.nc from Google Drive to GitHub

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -4,7 +4,7 @@ name: deploy-book
 # Only run this when the main branch changes
 on:
   # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
-  # pull_request:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -4,7 +4,7 @@ name: deploy-book
 # Only run this when the main branch changes
 on:
   # Uncomment the 'pull_request' line below to manually re-build Jupyter Book
-  pull_request:
+  # pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -33,7 +33,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         activate-environment: egu22pygmt
-        environment-file: environment.yml
+        environment-file: conda-lock.yml
         python-version: ${{ matrix.python-version }}
         channels: conda-forge
         channel-priority: strict

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -41,10 +41,6 @@ jobs:
             - conda-forge
             - nodefaults
 
-    # Show installed pkg information for postmortem diagnostic
-    - name: List installed packages
-      run: mamba list
-
     # Build the book
     - name: Build the book
       run: jupyter-book build book/

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -30,17 +30,16 @@ jobs:
 
     # Install Mambaforge with conda-forge dependencies
     - name: Setup Mambaforge
-      uses: conda-incubator/setup-miniconda@v2.1.1
+      uses: mamba-org/setup-micromamba@v1.9.0
       with:
-        activate-environment: egu22pygmt
+        environment-name: egu22pygmt
         environment-file: conda-lock.yml
-        python-version: ${{ matrix.python-version }}
-        channels: conda-forge
-        channel-priority: strict
-        miniforge-version: latest
-        miniforge-variant: Mambaforge
-        mamba-version: "*"
-        use-mamba: true
+        create-args: >-
+          python=${{ matrix.python-version }}
+        condarc: |
+          channels:
+            - conda-forge
+            - nodefaults
 
     # Show installed pkg information for postmortem diagnostic
     - name: List installed packages

--- a/book/mars_maps.ipynb
+++ b/book/mars_maps.ipynb
@@ -34,18 +34,16 @@
     "# Also, if you are in colab or trying from your jupyter, you will need the Mars Topography (MOLA) already in Netcdf\n",
     "# a copy of the original file distributed from the Mars Climate Database,\n",
     "# from the European Space Agency under ESTEC contract 11369/95/NL/JG(SC) and Centre National D'Etude Spatial\n",
-    "# is in the gdrive.\n",
+    "# is on GitHub.\n",
     "\n",
-    "!gdown 1fDzz8AxR1T58y0IGPhmbb1ZwrTLckp2G"
+    "!wget https://github.com/andrebelem/PlanetaryMaps/raw/v1.0/mola32.nc"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "11b04ce1",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import xarray as xr\n",

--- a/book/mars_maps_extended.ipynb
+++ b/book/mars_maps_extended.ipynb
@@ -75,13 +75,12 @@
    },
    "outputs": [],
    "source": [
-    "\n",
     "# Also, if you are in colab or trying from your jupyter, you will need the Mars Topography (MOLA) already in Netcdf\n",
     "# a copy of the original file distributed from the Mars Climate Database,\n",
     "# from the European Space Agency under ESTEC contract 11369/95/NL/JG(SC) and Centre National D'Etude Spatial\n",
-    "# is in the gdrive.\n",
+    "# is on GitHub.\n",
     "\n",
-    "!gdown 1fDzz8AxR1T58y0IGPhmbb1ZwrTLckp2G"
+    "!wget https://github.com/andrebelem/PlanetaryMaps/raw/v1.0/mola32.nc"
    ]
   },
   {


### PR DESCRIPTION
Google Drive link was broken, so the Mars notebook didn't work.

![image](https://github.com/GenericMappingTools/egu22pygmt/assets/23487320/fc20a1e1-61c1-44f2-a6ee-46cbc7aa4ad8)

Updated to download the `mola32.nc` file using a new copy available at https://github.com/andrebelem/PlanetaryMaps/blob/v1.0/mola32.nc. Courtesy of @andrebelem.

Also updating the JupyterBook build CI to install from the `conda-lock.yml` file instead of `environment.yml` to reproduce the old environment from 2022. Needed to switch from `setup-miniconda` to `setup-micromamba` for this.